### PR TITLE
Routes and translations are application-specific.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ A Symfony2 bundle that holds shared code and framework integration for all Step-
         $bundles[] = new Surfnet\StepupBundle\SurfnetStepupBundle;
     }
     ```
+
+ * Copy and adjust the error templates to your application folder
+    * `src/Resources/views/Exception/error.html.twig` → `app/Resources/SurfnetStepupBundle/views/Exception/error.html.twig`
+    * `src/Resources/views/Exception/error404.html.twig` → `app/Resources/SurfnetStepupBundle/views/Exception/error404.html.twig`

--- a/src/Resources/views/Exception/error.html.twig
+++ b/src/Resources/views/Exception/error.html.twig
@@ -1,14 +1,14 @@
 {% extends '::base.html.twig' %}
 
-{% block page_title %}{{ 'ss.error.title'|trans({'status_code': statusCode, 'status_text': statusText}) }}{% endblock %}
+{% block page_title %}{{ 'Error' }}{% endblock %}
 
 {% block content %}
     <h2>{{ block('page_title') }}</h2>
 
-    <p>{{ 'ss.error.text.an_error_occurred'|trans({'status_code': statusCode, 'status_text': statusText}) }}</p>
-    <a class="btn btn-primary" href="{{ path('ss_entry_point') }}">{{ 'ss.error.button.go_home'|trans }}</a>
+    <p>{{ 'A error occurred due to an unknown cause. Go back and try again or go to the homepage.' }}</p>
+    <a class="btn btn-primary" href="/">{{ 'To the homepage' }}</a>
 
     <hr>
-    <p>{{ 'ss.error.text.your_art_code'|trans }}: <span class="art">#{{ art }}</span></p>
-    <p>{{ 'ss.error.text.what_were_you_doing_well_fix_it'|trans }}</p>
+    <p>{{ 'The error code for the error is' }}: <span class="art">#{{ art }}</span></p>
+    <p>{{ 'If you think this error is a mistake, please report it to SURFnet.' }}</p>
 {% endblock %}

--- a/src/Resources/views/Exception/error404.html.twig
+++ b/src/Resources/views/Exception/error404.html.twig
@@ -1,14 +1,14 @@
 {% extends '::base.html.twig' %}
 
-{% block page_title %}{{ 'ss.error.page_not_found.title'|trans }}{% endblock %}
+{% block page_title %}{{ 'Page not found' }}{% endblock %}
 
 {% block content %}
     <h2>{{ block('page_title') }}</h2>
 
-    <p>{{ 'ss.error.text.page_not_found'|trans }}</p>
-    <a class="btn btn-primary" href="{{ path('ss_entry_point') }}">{{ 'ss.error.button.go_home'|trans }}</a>
+    <p>{{ 'The page you requested was not found. Go back to try again or go to the homepage.' }}</p>
+    <a class="btn btn-primary" href="/">{{ 'To the homepage' }}</a>
 
     <hr>
-    <p>{{ 'ss.error.text.your_art_code'|trans }}: <span class="art">#{{ art }}</span></p>
-    <p>{{ 'ss.error.text.if_you_think_this_is_incorrect_report'|trans }}</p>
+    <p>{{ 'The error code for the error is' }}: <span class="art">#{{ art }}</span></p>
+    <p>{{ 'If you think this error is a mistake, please report it to SURFnet.' }}</p>
 {% endblock %}


### PR DESCRIPTION
This makes the error templates an example for integrators of this bundle.