### PR TITLE
Revert "Configure empty LOA definitions by default"

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -75,8 +75,6 @@ services:
 
     surfnet_stepup.service.loa_resolution:
         class: Surfnet\StepupBundle\Service\LoaResolutionService
-        arguments:
-            - [] # Set in extension
 
     surfnet_stepup.service.gateway_api_sms:
         public: false


### PR DESCRIPTION
This reverts commit 992fd975bf4cdfbf1cd3097f1eecb53fffdf0c3b.